### PR TITLE
Changed deprecated Paragraph to Text

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -37,11 +37,11 @@ function M:peek()
 	if self.skip > 0 and i < self.skip + limit then
 		ya.manager_emit(
 			"peek",
-			{ tostring(math.max(0, i - limit)), only_if = tostring(self.file.url), upper_bound = "" }
+			{ math.max(0, i - limit), only_if = self.file.url, upper_bound = true }
 		)
 	else
 		lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
-		ya.preview_widgets(self, { ui.Paragraph.parse(self.area, lines) })
+		Ra.preview_widgets(self, { ui.Text.parse(lines):area(self.area) })
 	end
 end
 


### PR DESCRIPTION
The current version of miller will throw the next warning in the latest version of yazi.

```
The  `ui.Paragraph` and `ui.ListItem` elements have been deprecated in Yazi v0.4.

Please use the new `ui.Text` instead, in your `miller.yazi` plugin. See #1772 
for details: https://github.com/sxyazi/yazi/issues/1772
```

This pull request implements the new yazi API.