### PR TITLE
migrate to Yazi v0.4.0

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M:peek()
+function M:peek(job)
 	local child = Command("mlr")
 			:args({
 				"--icsv",
@@ -11,13 +11,13 @@ function M:peek()
 				"--value-color",
 				"grey70",
 				"cat",
-				tostring(self.file.url),
+				tostring(job.file.url),
 			})
 			:stdout(Command.PIPED)
 			:stderr(Command.PIPED)
 			:spawn()
 
-	local limit = self.area.h
+	local limit = job.area.h
 	local i, lines = 0, ""
 	repeat
 		local next, event = child:read_line()
@@ -28,30 +28,30 @@ function M:peek()
 		end
 
 		i = i + 1
-		if i > self.skip then
+		if i > job.skip then
 			lines = lines .. next
 		end
-	until i >= self.skip + limit
+	until i >= job.skip + limit
 
 	child:start_kill()
-	if self.skip > 0 and i < self.skip + limit then
+	if job.skip > 0 and i < job.skip + limit then
 		ya.manager_emit(
 			"peek",
-			{ tostring(math.max(0, i - limit)), only_if = tostring(self.file.url), upper_bound = "" }
+			{ tostring(math.max(0, i - limit)), only_if = tostring(job.file.url), upper_bound = "" }
 		)
 	else
 		lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
-		ya.preview_widgets(self, { ui.Paragraph.parse(self.area, lines) })
+		ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area) })
 	end
 end
 
-function M:seek(units)
+function M:seek(job)
 	local h = cx.active.current.hovered
-	if h and h.url == self.file.url then
-		local step = math.floor(units * self.area.h / 10)
+	if h and h.url == job.file.url then
+		local step = math.floor(job.units * job.area.h / 10)
 		ya.manager_emit("peek", {
 			tostring(math.max(0, cx.active.preview.skip + step)),
-			only_if = tostring(self.file.url),
+			only_if = tostring(job.file.url),
 		})
 	end
 end


### PR DESCRIPTION
Fix deprecation messages for following changes:

https://github.com/sxyazi/yazi/pull/1966
Task information for peek()/seek()/preload() has been moved from `self` to the first parameter `job`.

https://github.com/sxyazi/yazi/issues/1772
ui.Paragraph() has been deprecated in favor of ui.Text()

Please check if this is correctly done, it worked for me and got rid of the deprecation messages and shows csv again correctly.